### PR TITLE
Fill the find-and-replace text with current selection every time it's activated

### DIFF
--- a/FlashDevelop/Dialogs/FRInFilesDialog.cs
+++ b/FlashDevelop/Dialogs/FRInFilesDialog.cs
@@ -888,7 +888,6 @@ namespace FlashDevelop.Dialogs
         private void UpdateDialogArguments()
         {
             IProject project = PluginBase.CurrentProject;
-            ITabbedDocument document = Globals.CurrentDocument;
             Boolean doRefresh = lastProject != null && lastProject != project;
             if (project != null)
             {
@@ -919,10 +918,7 @@ namespace FlashDevelop.Dialogs
                     this.extensionComboBox.Text = "*." + def;
                 }
             }
-            if (document.IsEditable && document.SciControl.SelText.Length > 0)
-            {
-                this.findComboBox.Text = document.SciControl.SelText;
-            }
+            UpdateFindTextWithSelection();
             if (project != null) lastProject = project;
         }
 
@@ -1055,6 +1051,18 @@ namespace FlashDevelop.Dialogs
         {
             this.UpdateDialogArguments();
             base.Show();
+        }
+
+        /// <summary>
+        /// Update the find combo box with the currently selected text.
+        /// </summary>
+        public void UpdateFindTextWithSelection()
+        {
+            ITabbedDocument document = Globals.CurrentDocument;
+            if (document.IsEditable && document.SciControl.SelText.Length > 0)
+            {
+                this.findComboBox.Text = document.SciControl.SelText;
+            }
         }
 
         #endregion

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -2938,7 +2938,11 @@ namespace FlashDevelop
         public void FindAndReplaceInFiles(Object sender, System.EventArgs e)
         {
             if (!this.frInFilesDialog.Visible) this.frInFilesDialog.Show();
-            else this.frInFilesDialog.Activate();
+            else
+            {
+                this.frInFilesDialog.UpdateFindTextWithSelection();
+                this.frInFilesDialog.Activate();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When opening the find-and-replace dialog the first time it automatically populates the find text with whatever you have selected. Every additional attempt will no longer update the text.

This change makes it so every time you activate the dialog, usually through Ctrl+Shift+F, it will update the find text to use whatever you had selected at the time, making it much easier to use.
